### PR TITLE
hack to build with esbuild/npm current versions.

### DIFF
--- a/effects/dark-dynamic-digital-rain.ts
+++ b/effects/dark-dynamic-digital-rain.ts
@@ -1,3 +1,12 @@
+declare global {
+  interface Window {
+      Obsidian_Dynamic_Background_Start: () => void;
+      Obsidian_Dynamic_Background_Draw: () => void;
+      Obsidian_Dynamic_Background_Clear: () => void;
+      Obsidian_Dynamic_Background_SetBrightness: () => void;
+  }
+}
+
 export let DarkTheme_Digital_Rain_Background_Property = "radial-gradient(ellipse at bottom, #1b2735 20%, #090a0f 100%)";
 
 // Add Digital Rain dynamic background effect for dark theme
@@ -85,10 +94,10 @@ export function Remove_DigitalRain(dynamicBackgroundContainer: HTMLDivElement){
 
 function Unload_Effect_Script()
 {  
-  window["Obsidian_Dynamic_Background_Start"] = null;
-  window["Obsidian_Dynamic_Background_Draw"] = null;
-  window["Obsidian_Dynamic_Background_Clear"] = null;
-  window["Obsidian_Dynamic_Background_SetBrightness"] = null;
+  window["Obsidian_Dynamic_Background_Start"] = () => {};
+  window["Obsidian_Dynamic_Background_Draw"] = () => {};
+  window["Obsidian_Dynamic_Background_Clear"] = () => {};
+  window["Obsidian_Dynamic_Background_SetBrightness"] = () => {};
 }
 
 function CallClear(dynamicBackgroundContainer: HTMLDivElement){

--- a/effects/dark-dynamic-random-circle.ts
+++ b/effects/dark-dynamic-random-circle.ts
@@ -1,3 +1,11 @@
+declare global {
+  interface Window {
+      Obsidian_Dynamic_Background_Start: () => void;
+      Obsidian_Dynamic_Background_Firework: () => void;
+      Obsidian_Dynamic_Background_Animate: () => void;
+  }
+}
+
 export let DarkTheme_Random_Circle_Background_Property = "radial-gradient(ellipse at bottom, #1b2735 20%, #090a0f 100%)";
 
 // Add Random Circle dynamic background effect for dark theme
@@ -102,7 +110,7 @@ export function Remove_RandomCircle(dynamicBackgroundContainer: HTMLDivElement){
 
 function Unload_Effect_Script()
 {
-  window["Obsidian_Dynamic_Background_Start"] = null;
-  window["Obsidian_Dynamic_Background_Firework"] = null;
-  window["Obsidian_Dynamic_Background_Animate"] = null;
+  window["Obsidian_Dynamic_Background_Start"] = () => {};
+  window["Obsidian_Dynamic_Background_Firework"] = () => {};
+  window["Obsidian_Dynamic_Background_Animate"] = () => {};
 }

--- a/effects/light-dynamic-random-circle.ts
+++ b/effects/light-dynamic-random-circle.ts
@@ -1,3 +1,11 @@
+declare global {
+  interface Window {
+      Obsidian_Dynamic_Background_Start: () => void;
+      Obsidian_Dynamic_Background_Firework: () => void;
+      Obsidian_Dynamic_Background_Animate: () => void;
+  }
+}
+
 export let LightTheme_Random_Circle_Background_Property = "linear-gradient(0deg, rgba(255,255,255,1) 62%, rgba(230,244,255,1) 100%)";
 
 // Add Random Circle dynamic background effect for light theme
@@ -101,7 +109,7 @@ export function Remove_RandomCircle_Light(dynamicBackgroundContainer: HTMLDivEle
 }
 
 function Unload_Effect_Script(){
-  window["Obsidian_Dynamic_Background_Start"] = null;
-  window["Obsidian_Dynamic_Background_Firework"] = null;
-  window["Obsidian_Dynamic_Background_Animate"] = null;
+  window["Obsidian_Dynamic_Background_Start"] = () => {};
+  window["Obsidian_Dynamic_Background_Firework"] = () => {};
+  window["Obsidian_Dynamic_Background_Animate"] = () => {};
 }

--- a/effects/light-dynamic-wave.ts
+++ b/effects/light-dynamic-wave.ts
@@ -1,3 +1,9 @@
+declare global {
+  interface Window {
+      Obsidian_Dynamic_Background_ShowWave: () => void;
+  }
+}
+
 export let LightTheme_Wave_Background_Property = "linear-gradient(0deg, rgba(255,255,255,1) 60%, rgba(201,233,255,1) 100%)";
 
 // Add Wave dynamic background effect for light theme
@@ -45,5 +51,5 @@ export function Remove_Wave_Light(dynamicBackgroundContainer: HTMLDivElement){
 }
 
 function Unload_Effect_Script(){
-  window["Obsidian_Dynamic_Background_ShowWave"] = null;
+  window["Obsidian_Dynamic_Background_ShowWave"] = () => {};
 }


### PR DESCRIPTION
Found your version, liked the extra's you've added, and tried to build with `esbuild`.

All the effects fails to build with `error TS7015: Element implicitly has an 'any' type because index expression is not of type 'number'` when ever there is something like `window["Obsidian_Dynamic_Background_Clear"] = null`. 

I think this is trying to dynamically remove, or at least remove the body of the function(s), that drive the given effect.

This change is what worked (ie loads in obsidian, yet to crash...) after Googling "how to dynamically access functions added to the Window object in typescript."  I've not used typescript before, so I'm sure there is a better way!

ESbuild version: `npm run build --version` gives `10.8.2`.

